### PR TITLE
양희철-(일정 페이지): 카카오 지도 다각형 오버레이 중심점 마커 찍기 구현, 위치 목업 데이터 추가

### DIFF
--- a/src/components/units/room/Halfway.jsx
+++ b/src/components/units/room/Halfway.jsx
@@ -1,0 +1,68 @@
+import { MapMarker, Polygon } from "react-kakao-maps-sdk";
+
+function calcCenter(markers) {
+  let x = 0;
+  let y = 0;
+  let s = 0;
+
+  for (let i = 0; i < markers.length; i++) {
+    let j = (i + 1) % markers.length;
+
+    x +=
+      (markers[i].lat + markers[j].lat) *
+      (markers[i].lat * markers[j].lng - markers[j].lat * markers[i].lng);
+    y +=
+      (markers[i].lng + markers[j].lng) *
+      (markers[i].lat * markers[j].lng - markers[j].lat * markers[i].lng);
+    s += markers[i].lat * markers[j].lng - markers[j].lat * markers[i].lng;
+  }
+  s /= 2;
+  x = x / (6 * s);
+  y = y / (6 * s);
+  return { lat: x, lng: y };
+}
+
+const Halfway = ({ markers }) => {
+  const halfwayPoint = calcCenter(markers);
+  return (
+    <>
+      {markers.map((marker) => (
+        <MapMarker
+          key={`${marker.lat}-${marker.lng}`}
+          position={marker}
+          image={{
+            src: "https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png",
+            size: {
+              width: 24,
+              height: 35,
+            },
+          }}
+        />
+      ))}
+      <MapMarker
+        key={"halfway"}
+        position={halfwayPoint}
+        image={{
+          src: "https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/markerStar.png",
+          size: {
+            width: 24,
+            height: 35,
+          },
+        }}
+      >
+        {"1"}
+      </MapMarker>
+      <Polygon
+        path={markers.map((marker) => marker)}
+        strokeWeight={1} // 선의 두께입니다
+        strokeColor={"#39DE2A"} // 선의 색깔입니다
+        strokeOpacity={0.8} // 선의 불투명도 입니다 1에서 0 사이의 값이며 0에 가까울수록 투명합니다
+        strokeStyle={"solid"} // 선의 스타일입니다
+        fillColor={"#A2FF99"} // 채우기 색깔입니다
+        fillOpacity={0.7}
+      />
+    </>
+  );
+};
+
+export default Halfway;

--- a/src/components/units/room/KakaoMap.jsx
+++ b/src/components/units/room/KakaoMap.jsx
@@ -1,5 +1,14 @@
 import useKakaoLoader from "@/hooks/useKakaoLoader";
 import { Map } from "react-kakao-maps-sdk";
+import Halfway from "./Halfway";
+
+const MARKERS = [
+  { lat: 33.450705, lng: 126.570677 },
+  { lat: 33.450936, lng: 126.569477 },
+  { lat: 33.451979, lng: 126.56994 },
+  { lat: 33.451393, lng: 126.570738 },
+  { lat: 33.451493, lng: 126.571018 },
+];
 
 function KakaoMap() {
   const [loading, error] = useKakaoLoader();
@@ -7,7 +16,12 @@ function KakaoMap() {
   if (loading) return <div>Loading</div>;
 
   return (
-    <Map center={{ lat: 33.5563, lng: 126.79581 }} style={{ width: "100%", height: "360px" }}></Map>
+    <Map
+      center={{ lat: 33.450701, lng: 126.570667 }}
+      style={{ width: "100%", height: "360px" }}
+    >
+      <Halfway markers={MARKERS} />
+    </Map>
   );
 }
 


### PR DESCRIPTION
## 왜 필요한가요?

- 관련 이슈: 유저들이 찍은 마커들로 생성된 다각형 오버레이의 중심점을 보여줘야합니다.
> - 중심점 구하기에 사용한 수학 공식
> <img width="460" alt="스크린샷 2024-02-24 오전 3 36 06" src="https://github.com/ketchup0211/where-we-meet/assets/100992153/b737290c-962d-42d9-a397-c9278e57eb10">

## 어떤 변화가 생겼나요?

- /components/units/room 안에 Halfway.jsx 파일을 만들어서 지도에 다각형 오버레이안에 중심점 마커를 찍는 컴포넌트를 만들어 export한다
- KakaoMap.jsx 파일안에 Halfway 컴포넌트를 import해 Map 컴포넌트의 children으로 넣는다.
- KakaoMap.jsx 파일에 목업 좌표 데이터 추가
- 지도에 다각형 오버레이 생성, 중심점 마커 생성

## 스크린샷
<img width="921" alt="스크린샷 2024-02-24 오전 3 49 48" src="https://github.com/ketchup0211/where-we-meet/assets/100992153/8fb8b6b6-ad67-4257-b821-3b4b6578962b">
