### PR TITLE
나의찬-(일정 페이지) 중심점 반경 원그리기

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "printWidth": 120,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "bracketSpacing": true,
+  "trailingComma": "none"
+}

--- a/index.html
+++ b/index.html
@@ -8,10 +8,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script
-      type="text/javascript"
-      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=발급받은 APP KEY를 넣으시면 됩니다.&libraries=services,clusterer"
-    ></script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/src/components/units/room/KakaoMap.jsx
+++ b/src/components/units/room/KakaoMap.jsx
@@ -1,13 +1,25 @@
-import useKakaoLoader from "@/hooks/useKakaoLoader";
-import { Map } from "react-kakao-maps-sdk";
+import useKakaoLoader from '@/hooks/useKakaoLoader';
+import { useState } from 'react';
+import { Map } from 'react-kakao-maps-sdk';
+import KakaoMapCircle from './KakaoMapCircle';
 
 function KakaoMap() {
   const [loading, error] = useKakaoLoader();
+  const [zoomLevel, setZoomLevel] = useState(3);
 
   if (loading) return <div>Loading</div>;
 
   return (
-    <Map center={{ lat: 33.5563, lng: 126.79581 }} style={{ width: "100%", height: "360px" }}></Map>
+    <Map
+      center={{ lat: 33.5563, lng: 126.79581 }}
+      style={{ width: '100%', height: '360px' }}
+      onZoomChanged={(map) => {
+        const level = map.getLevel();
+        setZoomLevel(level);
+      }}
+    >
+      <KakaoMapCircle zoomLevel={zoomLevel} />
+    </Map>
   );
 }
 

--- a/src/components/units/room/KakaoMapCircle.jsx
+++ b/src/components/units/room/KakaoMapCircle.jsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import { Circle } from 'react-kakao-maps-sdk';
+
+const RADIUS_MAXRANGE = [50, 100, 250, 400, 700, 2000, 5000, 8000, 10000, 10000];
+
+function KakaoMapCircle({ center = { lat: 33.5563, lng: 126.79581 }, zoomLevel }) {
+  const [radiusPercent, setRadiusPercent] = useState(0);
+  const radius = (radiusPercent * RADIUS_MAXRANGE[zoomLevel <= RADIUS_MAXRANGE.length ? zoomLevel : 9]) / 100;
+  const drawingCircleData = { center, radius };
+
+  const handleChangeRange = (e) => {
+    setRadiusPercent(e.target.value);
+  };
+
+  return (
+    <>
+      <Circle
+        center={drawingCircleData.center}
+        radius={drawingCircleData.radius}
+        strokeWeight={3}
+        strokeColor={'#000000'}
+        strokeOpacity={0.2}
+        strokeStyle={'solid'}
+        fillColor={'#00a0e9'}
+        fillOpacity={0.2}
+      />
+      <div>
+        <input type="range" min={0} max={100} value={radiusPercent} onChange={handleChangeRange}></input>
+        반경 {radius}m
+      </div>
+      <button onClick={() => setRadiusPercent(0)}>범위 지우기!</button>
+    </>
+  );
+}
+
+export default KakaoMapCircle;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,7 +3,5 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+  <App />
 );

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,5 +3,5 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
-  <App />
+    <App />
 );


### PR DESCRIPTION
## 왜 필요한가요?

- 중심점으로부터 반경을 가져와 원 그리기

## 어떤 변화가 생겼나요?

- /components/units/room 안에 KakaoMapCircle.jsx 파일을 만들어서 원을 그리는 컴포넌트를 만들어 export한다
- KakaoMap.jsx 파일에서 import 
- KakaoMap.jsx 파일에 onZoomChanged 지도 레벨이 바뀌는 것을 감지해서 zoomLevel 가져옴
- 지도에서 중심점을 기준으로 반경을 선택해서 원을 그릴 수 있고 지도표시 레벨에 따라 선택할 수 있는 최대 반경이 바뀜.

## 스크린샷

![Snipaste_2024-02-26_09-51-13](https://github.com/ketchup0211/where-we-meet/assets/85791020/73fa016e-5de4-48a0-96f4-dae859db1099)

