### PR TITLE
나의찬-(맵) 중간지점 줌레벨 초기화

### DIFF
--- a/src/components/units/room/CenterFlagButton.jsx
+++ b/src/components/units/room/CenterFlagButton.jsx
@@ -1,7 +1,7 @@
 import { useDispatch, useSelector } from 'react-redux';
 import style from './CenterFlagButton.module.css';
 import { FaFlag } from 'react-icons/fa';
-import { setViewPoint } from '@/redux/modules/mapSlice';
+import { setViewPoint, setZoomLevel } from '@/redux/modules/mapSlice';
 
 function CenterFlagButton() {
   const dispatch = useDispatch();
@@ -9,7 +9,9 @@ function CenterFlagButton() {
 
   const moveViewPointToCenter = () => {
     dispatch(setViewPoint(center));
+    dispatch(setZoomLevel(3));
   };
+
   return (
     <button className={style.button} onClick={moveViewPointToCenter}>
       <FaFlag className={style.button_icon} />

--- a/src/components/units/room/KakaoMap.jsx
+++ b/src/components/units/room/KakaoMap.jsx
@@ -1,35 +1,42 @@
 import useKakaoLoader from '@/hooks/useKakaoLoader';
-import { useState } from 'react';
 import { Map } from 'react-kakao-maps-sdk';
 import KakaoMapCircle from './KakaoMapCircle';
 import Halfway from './Halfway';
 import styles from './KakaoMap.module.css';
 import { useDispatch, useSelector } from 'react-redux';
 import CenterFlagButton from './CenterFlagButton';
-import { setViewPoint } from '@/redux/modules/mapSlice';
+import { setViewPoint, setZoomLevel } from '@/redux/modules/mapSlice';
 
 function KakaoMap() {
   const [loading, error] = useKakaoLoader();
-  const [zoomLevel, setZoomLevel] = useState(3);
   const dispatch = useDispatch();
 
+  const zoomLevel = useSelector((state) => state.mapSlice.zoomLevel);
   const viewPoint = useSelector((state) => state.mapSlice.viewPoint);
 
+  const handleViewPoint = (map) => {
+    const latlng = map.getCenter();
+    const currentLatLng = { lat: latlng.getLat(), lng: latlng.getLng() };
+    dispatch(setViewPoint(currentLatLng));
+  };
+
   if (loading) return <div>Loading</div>;
+  if (error) return <div>error</div>;
 
   return (
     <>
       <Map
         center={viewPoint}
         className={styles.map}
+        level={zoomLevel}
         onZoomChanged={(map) => {
           const level = map.getLevel();
-          setZoomLevel(level);
+          dispatch(setZoomLevel(level));
+
+          handleViewPoint(map);
         }}
         onDragEnd={(map) => {
-          const latlng = map.getCenter();
-          const currentLatLng = { lat: latlng.getLat(), lng: latlng.getLng() };
-          dispatch(setViewPoint(currentLatLng));
+          handleViewPoint(map);
         }}
       >
         <Halfway />

--- a/src/components/units/room/KakaoMap.module.css
+++ b/src/components/units/room/KakaoMap.module.css
@@ -5,8 +5,9 @@
   border: 2px solid #ddd;
 }
 
-.map_footer{
+.map_footer {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  align-items: center;
 }

--- a/src/redux/modules/mapSlice.js
+++ b/src/redux/modules/mapSlice.js
@@ -2,7 +2,8 @@ import { createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
   viewPoint: { lat: 37.50232593365278, lng: 127.04444559870342 },
-  centerPoint: null
+  centerPoint: null,
+  zoomLevel: 3
 };
 
 const mapSlice = createSlice({
@@ -15,9 +16,12 @@ const mapSlice = createSlice({
     setCenterPoint: (state, action) => {
       if (action.payload === undefined) return;
       state.centerPoint = action.payload;
+    },
+    setZoomLevel: (state, action) => {
+      state.zoomLevel = action.payload;
     }
   }
 });
 
-export const { setViewPoint, setCenterPoint } = mapSlice.actions;
+export const { setViewPoint, setCenterPoint, setZoomLevel } = mapSlice.actions;
 export default mapSlice.reducer;


### PR DESCRIPTION
## 왜 필요한가요?

- 중간 지점으로 이동 버튼에서 줌레벨도 3레벨로 초기화
- 중간 지점 이동 위치 스타일 수정

## 어떤 변화가 생겼나요?

- 줌레벨 전역상태로 관리
- 중간 지점 이동 위치 스타일 수정

## 스크린샷
![image](https://github.com/ketchup0211/where-we-meet/assets/85791020/5dbfff31-8cbd-47cd-8bf5-5d9a0932ecbd)
![2024 2 28 맵이동](https://github.com/ketchup0211/where-we-meet/assets/85791020/3be7a569-9325-43ea-ac07-5c1936c83176)