### PR TITLE
참-(룸) : range 전역 상태 관리로 전환

### DIFF
--- a/src/components/units/room/KakaoMapCircle.jsx
+++ b/src/components/units/room/KakaoMapCircle.jsx
@@ -1,18 +1,22 @@
-import { useState } from 'react';
 import { Circle } from 'react-kakao-maps-sdk';
 import styles from './KakaoMapCircle.module.css';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import { setRange } from '@/redux/modules/rangeSlice';
 
 const RADIUS_MAXRANGE = [50, 100, 250, 400, 700, 2000, 5000, 8000, 10000];
 
 function KakaoMapCircle({ zoomLevel }) {
-  const [radius, setRadius] = useState(50);
+  const dispatch = useDispatch();
+  const radius = useSelector((state) => state.rangeSlice.range);
   const center = useSelector((state) => state.mapSlice.centerPoint);
 
   const handleChangeRange = (e) => {
-    setRadius(e.target.value);
+    dispatch(setRange(e.target.value));
   };
 
+  const resetRange = () => {
+    dispatch(setRange(0));
+  };
   if (center === null) return;
 
   return (
@@ -35,7 +39,7 @@ function KakaoMapCircle({ zoomLevel }) {
           value={radius}
           onChange={handleChangeRange}
         ></input>
-        반경 {radius}m<button onClick={() => setRadius(0)}>범위 지우기!</button>
+        반경 {radius}m<button onClick={resetRange}>범위 지우기!</button>
       </div>
     </>
   );

--- a/src/redux/config/configStore.jsx
+++ b/src/redux/config/configStore.jsx
@@ -1,6 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit';
 import mapSlice from '../modules/mapSlice';
+import rangeSlice from '../modules/rangeSlice';
 
-const store = configureStore({ reducer: { mapSlice } });
+const store = configureStore({ reducer: { mapSlice, rangeSlice } });
 
 export default store;

--- a/src/redux/modules/rangeSlice.js
+++ b/src/redux/modules/rangeSlice.js
@@ -1,0 +1,18 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  range: 0
+};
+
+const rangeSlice = createSlice({
+  name: 'range',
+  initialState,
+  reducers: {
+    setRange: (state, action) => {
+      state.range = action.payload;
+    }
+  }
+});
+
+export const { setRange } = rangeSlice.actions;
+export default rangeSlice.reducer;

--- a/src/redux/modules/rangeSlice.js
+++ b/src/redux/modules/rangeSlice.js
@@ -1,7 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
-  range: 0
+  range: 50
 };
 
 const rangeSlice = createSlice({


### PR DESCRIPTION
## 왜 필요한가요?

- range 기반 장소 필터링을 위해 range 값을 전역으로 관리하도록 변경해야합니다.

## 어떤 변화가 생겼나요?

- rangeSlice.js reducer를 생성하였습니다.
- 지역으로 관리하던 range를 전역 상태로 전환하여 사용하였습니다.
- resetRange 함수를 만들어 범위 지우기 기능을 명확히 하였습니다. (코드 개선)

## 스크린샷
<img width="597" alt="스크린샷 2024-02-28 오후 4 08 36" src="https://github.com/ketchup0211/where-we-meet/assets/69431340/b8cf796b-b242-4c06-88fb-a085bb2627da">
<img width="592" alt="스크린샷 2024-02-28 오후 4 09 35" src="https://github.com/ketchup0211/where-we-meet/assets/69431340/4aed133e-2f51-4f0c-9116-0915de5e8b7e">
<img width="592" alt="스크린샷 2024-02-28 오후 4 10 04" src="https://github.com/ketchup0211/where-we-meet/assets/69431340/e2e97e80-0806-4221-bd45-a426959180ef">
<img width="592" alt="스크린샷 2024-02-28 오후 4 10 39" src="https://github.com/ketchup0211/where-we-meet/assets/69431340/9b31a27e-f81d-4e13-b565-4d81522ad416">
