### PR TITLE
양희철-버그 수정 : 모바일 위치 지정 버튼 클릭 무시

### DIFF
--- a/src/components/units/room/MapWithSearch.jsx
+++ b/src/components/units/room/MapWithSearch.jsx
@@ -93,8 +93,7 @@ function MapWithSearch() {
     handleChangeViewPoint(place);
   };
   //viewpoint 변경 (state update)
-  const handleChangeViewPoint = (place, event) => {
-    event.stopPropagation();
+  const handleChangeViewPoint = (place) => {
     dispatch(setViewPoint(changeAxiosToViewPoint(place)));
   };
 
@@ -150,8 +149,8 @@ function MapWithSearch() {
             {placeList.map((place) => (
               <li
                 key={place.id}
-                onClick={(event) => {
-                  handleChangeViewPoint(place, event);
+                onClick={() => {
+                  handleChangeViewPoint(place);
                 }}
               >
                 <p className={styles.place_name}>{place.place_name}</p>
@@ -159,6 +158,9 @@ function MapWithSearch() {
                 <p className={styles.category_group_name}>{place.category_group_name}</p>
                 <button
                   onClick={() => {
+                    handleSetMyLocation(place);
+                  }}
+                  onTouchEnd={() => {
                     handleSetMyLocation(place);
                   }}
                 >


### PR DESCRIPTION
## 왜 필요한가요?
- pc에서 작동하던 버튼이 모바일에서는 작동하지 않아 이를 해결하기위해 필요합니다.

## 어떤 변화가 생겼나요?

- 기존 버튼의 코드에서는 onClick 핸들러에만 해당 이벤트 핸들러 함수가 있었지만 모바일 환경에서도 동작하기 위해 onTouchEnd 이벤트 핸들러를 추가했습니다.

## 스크린샷
<img width="295" alt="스크린샷 2024-02-29 오전 11 21 10" src="https://github.com/ketchup0211/where-we-meet/assets/100992153/f5be4a7d-f0b5-4592-824b-039c518fce01">
<img width="380" alt="문제 해결 gif" src="https://github.com/ketchup0211/where-we-meet/assets/100992153/4f8eb945-4f4a-4624-9852-7c330aa2e479">


